### PR TITLE
Markdown: show answer, display for clue references too

### DIFF
--- a/app/__tests__/Markdown.test.tsx
+++ b/app/__tests__/Markdown.test.tsx
@@ -89,4 +89,8 @@ test('clueMap rendering', async () => {
   r = render(<Markdown clueMap={clueMap} text={'You got it!! Glad the clues pointed you in the right direction. That\'s what they\'re there for. Also, it was Brian\'s suggestion to include >! BAM !< which I think is such an awesome addition. Cheers!'} />, {});
   await waitFor(() => {/* noop */ });
   expect(r.container).toMatchSnapshot();
+
+  r = render(<Markdown clueMap={clueMap} text='Reference 45A and 2D and unknown 11A' />, {});
+  await waitFor(() => {/* noop */ });
+  expect(r.container).toMatchSnapshot();
 });

--- a/app/__tests__/Markdown.test.tsx
+++ b/app/__tests__/Markdown.test.tsx
@@ -90,7 +90,7 @@ test('clueMap rendering', async () => {
   await waitFor(() => {/* noop */ });
   expect(r.container).toMatchSnapshot();
 
-  r = render(<Markdown clueMap={clueMap} text='Reference 45A and 2D and unknown 11A' />, {});
+  r = render(<Markdown clueMap={clueMap} text='Reference 45A and 2-D and 45-Across and 2Down and unknown 11A' />, {});
   await waitFor(() => {/* noop */ });
   expect(r.container).toMatchSnapshot();
 });

--- a/app/__tests__/__snapshots__/Markdown.test.tsx.snap
+++ b/app/__tests__/__snapshots__/Markdown.test.tsx.snap
@@ -108,8 +108,11 @@ exports[`clueMap rendering 2`] = `
           <b
             class="emotion-3"
           >
-            2
-            D
+            2D
+             
+            <code>
+              BAM
+            </code>
           </b>
           here is the clue?
           <div
@@ -202,8 +205,11 @@ exports[`clueMap rendering 3`] = `
         <b
           class="emotion-2"
         >
-          45
-          A
+          45A
+           
+          <code>
+            12ACLUE1
+          </code>
         </b>
         Well now
         <div
@@ -227,8 +233,11 @@ exports[`clueMap rendering 3`] = `
         <b
           class="emotion-2"
         >
-          2
-          D
+          2D
+           
+          <code>
+            BAM
+          </code>
         </b>
         here is the clue?
         <div
@@ -319,8 +328,11 @@ exports[`clueMap rendering 4`] = `
           <b
             class="emotion-3"
           >
-            2
-            D
+            2D
+             
+            <code>
+              BAM
+            </code>
           </b>
           here is the clue?
           <div
@@ -414,8 +426,11 @@ exports[`clueMap rendering 5`] = `
           <b
             class="emotion-3"
           >
-            2
-            D
+            2D
+             
+            <code>
+              BAM
+            </code>
           </b>
           here is the clue?
           <div
@@ -426,6 +441,124 @@ exports[`clueMap rendering 5`] = `
          
       </span>
        which I think is such an awesome addition. Cheers!
+    </div>
+  </div>
+</div>
+`;
+
+exports[`clueMap rendering 6`] = `
+.emotion-0 {
+  border-bottom: 1px dotted;
+  white-space: nowrap;
+}
+
+.emotion-1 {
+  z-index: 100000;
+  border-radius: 5px;
+  background-color: var(--black);
+  color: var(--white);
+  text-align: center;
+  max-width: 30em;
+  padding: 10px;
+  visibility: hidden;
+}
+
+.emotion-1[data-popper-reference-hidden=true] {
+  visibility: hidden;
+}
+
+.emotion-2 {
+  margin-right: 0.5em;
+}
+
+.emotion-3 {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+}
+
+[data-popper-placement^="bottom"] .emotion-3 {
+  top: -5px;
+}
+
+[data-popper-placement^="top"] .emotion-3 {
+  bottom: -5px;
+}
+
+.emotion-3::after {
+  content: " ";
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  width: 10px;
+  height: 10px;
+  background-color: var(--black);
+}
+
+<div>
+  <div>
+    <div
+      class="paragraph"
+    >
+      Reference 
+      <span
+        class="emotion-0"
+      >
+        45A
+      </span>
+      <div
+        class="emotion-1"
+        data-popper-escaped="true"
+        data-popper-placement="bottom"
+        data-popper-reference-hidden="true"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 10px);"
+      >
+        <b
+          class="emotion-2"
+        >
+          45A
+           
+          <code>
+            12ACLUE1
+          </code>
+        </b>
+        Well now
+        <div
+          class="emotion-3"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+        />
+      </div>
+       and 
+      <span
+        class="emotion-0"
+      >
+        2D
+      </span>
+      <div
+        class="emotion-1"
+        data-popper-escaped="true"
+        data-popper-placement="bottom"
+        data-popper-reference-hidden="true"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 10px);"
+      >
+        <b
+          class="emotion-2"
+        >
+          2D
+           
+          <code>
+            BAM
+          </code>
+        </b>
+        here is the clue?
+        <div
+          class="emotion-3"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+        />
+      </div>
+       and unknown 11A
     </div>
   </div>
 </div>

--- a/app/__tests__/__snapshots__/Markdown.test.tsx.snap
+++ b/app/__tests__/__snapshots__/Markdown.test.tsx.snap
@@ -534,7 +534,63 @@ exports[`clueMap rendering 6`] = `
       <span
         class="emotion-0"
       >
-        2D
+        2-D
+      </span>
+      <div
+        class="emotion-1"
+        data-popper-escaped="true"
+        data-popper-placement="bottom"
+        data-popper-reference-hidden="true"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 10px);"
+      >
+        <b
+          class="emotion-2"
+        >
+          2D
+           
+          <code>
+            BAM
+          </code>
+        </b>
+        here is the clue?
+        <div
+          class="emotion-3"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+        />
+      </div>
+       and 
+      <span
+        class="emotion-0"
+      >
+        45-Across
+      </span>
+      <div
+        class="emotion-1"
+        data-popper-escaped="true"
+        data-popper-placement="bottom"
+        data-popper-reference-hidden="true"
+        style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 10px);"
+      >
+        <b
+          class="emotion-2"
+        >
+          45A
+           
+          <code>
+            12ACLUE1
+          </code>
+        </b>
+        Well now
+        <div
+          class="emotion-3"
+          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+        />
+      </div>
+       and 
+      <span
+        class="emotion-0"
+      >
+        2Down
       </span>
       <div
         class="emotion-1"

--- a/app/components/Markdown.tsx
+++ b/app/components/Markdown.tsx
@@ -132,12 +132,21 @@ export const Markdown = ({
   className?: string;
 }) => {
   if (clueMap && clueMap.size) {
-    const fullClueMap = new Map<string, {fullClueNumber: string, answer: string, clue: string}>();
+    const fullClueMap = new Map<
+      string,
+      { fullClueNumber: string; answer: string; clue: string }
+    >();
     clueMap.forEach(([clueNumber, direction, clue], answer) => {
-      const fullClueNumber = `${clueNumber}${direction === Direction.Down ? 'D' : 'A'}`;
-      const entry = {fullClueNumber, answer, clue};
+      const longDirection = direction === Direction.Down ? 'Down' : 'Across';
+      const shortDirection = direction === Direction.Down ? 'D' : 'A';
+      const fullClueNumber = `${clueNumber}${shortDirection}`;
+      const entry = { fullClueNumber, answer, clue };
       fullClueMap.set(answer, entry);
-      fullClueMap.set(fullClueNumber, entry);
+      ['', '-'].forEach((separator) => {
+        [shortDirection, longDirection].forEach((directionText) => {
+          fullClueMap.set(`${clueNumber}${separator}${directionText}`, entry);
+        });
+      });
     });
 
     const regex =

--- a/app/components/Markdown.tsx
+++ b/app/components/Markdown.tsx
@@ -123,15 +123,26 @@ export const Markdown = ({
   className,
 }: {
   text: string;
+  // If this is included, references to clues by answer or full clue number will
+  // get a tooltip describing the referenced clues. This popup includes the
+  // answer, so only include this in a context where spoilers are OK!
   clueMap?: Map<string, [number, Direction, string]>;
   preview?: number;
   inline?: boolean;
   className?: string;
 }) => {
   if (clueMap && clueMap.size) {
+    const fullClueMap = new Map<string, {fullClueNumber: string, answer: string, clue: string}>();
+    clueMap.forEach(([clueNumber, direction, clue], answer) => {
+      const fullClueNumber = `${clueNumber}${direction === Direction.Down ? 'D' : 'A'}`;
+      const entry = {fullClueNumber, answer, clue};
+      fullClueMap.set(answer, entry);
+      fullClueMap.set(fullClueNumber, entry);
+    });
+
     const regex =
       '^([^0-9A-Za-z\\s\\u00c0-\\uffff]*[0-9A-Za-z\\s\\u00c0-\\uffff]*)\\b(' +
-      Array.from(clueMap.keys()).join('|') +
+      Array.from(fullClueMap.keys()).join('|') +
       ')\\b';
     const re = new RegExp(regex);
     const newRules = {
@@ -148,7 +159,7 @@ export const Markdown = ({
           };
         },
         react(node: any, recurseOutput: any, state: any) {
-          const mouseover = clueMap.get(node.content);
+          const mouseover = fullClueMap.get(node.content);
           if (!mouseover) {
             throw new Error('expected to find clue ' + node.content);
           }
@@ -160,10 +171,10 @@ export const Markdown = ({
                 tooltip={
                   <>
                     <b css={{ marginRight: '0.5em' }}>
-                      {mouseover[0]}
-                      {mouseover[1] === Direction.Down ? 'D' : 'A'}
+                      {mouseover.fullClueNumber}{' '}
+                      <code>{mouseover.answer}</code>
                     </b>
-                    {mouseover[2]}
+                    {mouseover.clue}
                   </>
                 }
               />


### PR DESCRIPTION
As far as I can tell, `<Markdown clueMap=...>` is only used in post-solve
comments so it should be OK to include the answer in the tooltip.

This implementation only supports `\d+[AD]` references; it could be generalized
later to support other ways of referring to clues.

Fixes #159.