### PR TITLE
Tiny readme adjustments to match Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Click "Firestore Database" in the side bar. Click "Create database". Choose "sta
 
 Click the little gear icon in the side bar and select "Project settings". Scroll to the "Your apps" section and click "</>" to create a web app. Register an app using whatever name you'd like. You don't need to set up hosting. 
 
-Copy the `const firebaseConfig = {...}` lines from the Add Firebase SDK dialog that pops up and paste them into a new file at `app/firebaseConfig.ts`. Change `var firebaseConfig` to `export const firebaseConfig`. These are the credentials used by the Crosshare frontend.
+Copy the `const firebaseConfig = {...}` lines from the Add Firebase SDK dialog that pops up and paste them into a new file at `app/firebaseConfig.ts`. Change `const firebaseConfig` to `export const firebaseConfig`. These are the credentials used by the Crosshare frontend.
 
 Now click "Continue to console" and click "Service accounts" at the top of the Project Settings page. Under "Firebase Admin SDK" click "Generate new private key". Save the resultant file as `serviceAccountKey.json` in the root of this repository. This is the credential file for the Crosshare server.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Click "Firestore Database" in the side bar. Click "Create database". Choose "sta
 
 Click the little gear icon in the side bar and select "Project settings". Scroll to the "Your apps" section and click "</>" to create a web app. Register an app using whatever name you'd like. You don't need to set up hosting. 
 
-Copy the `var firebaseConfig = {...}` lines from the Add Firebase SDK dialog that pops up and paste them into a new file at `app/firebaseConfig.ts`. Change `var firebaseConfig` to `export const firebaseConfig`. These are the credentials used by the Crosshare frontend.
+Copy the `const firebaseConfig = {...}` lines from the Add Firebase SDK dialog that pops up and paste them into a new file at `app/firebaseConfig.ts`. Change `var firebaseConfig` to `export const firebaseConfig`. These are the credentials used by the Crosshare frontend.
 
-Now click "Continue to console" and click "Service Accounts" at the top of the Project Settings page. Under "Firebase Admin SDK" click "Generate new private key". Save the resultant file as `serviceAccountKey.json` in the root of this repository. This is the credential file for the Crosshare server.
+Now click "Continue to console" and click "Service accounts" at the top of the Project Settings page. Under "Firebase Admin SDK" click "Generate new private key". Save the resultant file as `serviceAccountKey.json` in the root of this repository. This is the credential file for the Crosshare server.
 
 ### Install dependencies
 


### PR DESCRIPTION
I just went through this workflow and found a couple minor differences between the readme and Google's current website. Keeping the readme up to date with Google's current UI should help people who are unfamiliar with Firebase navigate the readme instructions more easily.

Screenshots below to show the UIs I encountered!
"Service accounts" instead of "Service Accounts":
![project settings screenshot](https://user-images.githubusercontent.com/4664975/132418200-d5bde63f-6070-4c66-bf2e-1b4b646d4329.jpg)
"const" instead of "var":
![firebase config screenshot](https://user-images.githubusercontent.com/4664975/132418202-d889cac1-8bff-4157-b454-a45065e077bd.jpg)