### PR TITLE
Rework keypress handling

### DIFF
--- a/app/components/Builder.tsx
+++ b/app/components/Builder.tsx
@@ -13,6 +13,7 @@ import {
 import { STORAGE_KEY } from '../lib/utils';
 import { ContactLinks } from './ContactLinks';
 import { isRight } from 'fp-ts/lib/Either';
+import { isSome } from 'fp-ts/lib/Option';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 import {
   FaRegNewspaper,
@@ -81,6 +82,9 @@ import {
   CancelAutofillMessage,
   PuzzleInProgressV,
   PuzzleInProgressT,
+  fromKeyString,
+  KeyK,
+  fromKeyboardEvent,
 } from '../lib/types';
 import {
   Symmetry,
@@ -1054,31 +1058,36 @@ const GridMode = ({
 
   const physicalKeyboardHandler = useCallback(
     (e: KeyboardEvent) => {
-      if (e.metaKey || e.altKey || e.ctrlKey || e.key === 'CapsLock') {
-        return; // This way you can still do apple-R and such
-      }
-      /* TODO this logic belongs in the reducer */
-      if (e.key === 'Enter' && !state.isEnteringRebus) {
-        reRunAutofill();
+      const tagName = (e.target as HTMLElement)?.tagName?.toLowerCase();
+      if (tagName === 'textarea' || tagName === 'input') {
         return;
       }
-      if (e.key === '!') {
-        const entry = getMostConstrainedEntry();
-        if (entry !== null) {
-          const ca: ClickedEntryAction = {
-            type: 'CLICKEDENTRY',
-            entryIndex: entry,
-          };
-          dispatch(ca);
+
+      const mkey = fromKeyboardEvent(e);
+      if (isSome(mkey)) {
+        /* TODO this logic belongs in the reducer */
+        if (mkey.value.k === KeyK.Enter && !state.isEnteringRebus) {
+          reRunAutofill();
+          e.preventDefault();
+          return;
         }
+        if (mkey.value.k === KeyK.Exclamation) {
+          const entry = getMostConstrainedEntry();
+          if (entry !== null) {
+            const ca: ClickedEntryAction = {
+              type: 'CLICKEDENTRY',
+              entryIndex: entry,
+            };
+            dispatch(ca);
+          }
+          e.preventDefault();
+          return;
+        }
+
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
+        dispatch(kpa);
+        e.preventDefault();
       }
-      const kpa: KeypressAction = {
-        type: 'KEYPRESS',
-        key: e.key,
-        shift: e.shiftKey,
-      };
-      dispatch(kpa);
-      e.preventDefault();
     },
     [dispatch, reRunAutofill, state.isEnteringRebus, getMostConstrainedEntry]
   );
@@ -1249,8 +1258,11 @@ const GridMode = ({
 
   const keyboardHandler = useCallback(
     (key: string) => {
-      const kpa: KeypressAction = { type: 'KEYPRESS', key: key, shift: false };
-      dispatch(kpa);
+      const mkey = fromKeyString(key);
+      if (isSome(mkey)) {
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
+        dispatch(kpa);
+      }
     },
     [dispatch]
   );
@@ -1525,8 +1537,7 @@ const GridMode = ({
                 onClick={() => {
                   const a: KeypressAction = {
                     type: 'KEYPRESS',
-                    key: '.',
-                    shift: false,
+                    key: { k: KeyK.Dot },
                   };
                   dispatch(a);
                 }}
@@ -1538,8 +1549,7 @@ const GridMode = ({
                 onClick={() => {
                   const a: KeypressAction = {
                     type: 'KEYPRESS',
-                    key: 'Escape',
-                    shift: false,
+                    key: { k: KeyK.Escape },
                   };
                   dispatch(a);
                 }}
@@ -1557,8 +1567,7 @@ const GridMode = ({
                 onClick={() => {
                   const a: KeypressAction = {
                     type: 'KEYPRESS',
-                    key: '`',
-                    shift: false,
+                    key: { k: KeyK.Tilde },
                   };
                   dispatch(a);
                 }}

--- a/app/components/Builder.tsx
+++ b/app/components/Builder.tsx
@@ -1567,7 +1567,7 @@ const GridMode = ({
                 onClick={() => {
                   const a: KeypressAction = {
                     type: 'KEYPRESS',
-                    key: { k: KeyK.Tilde },
+                    key: { k: KeyK.Backtick },
                   };
                   dispatch(a);
                 }}

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -4,6 +4,7 @@ import { FaAngleDoubleRight, FaAngleDoubleLeft } from 'react-icons/fa';
 import { Square } from './Square';
 import { KeypressAction } from '../reducers/reducer';
 import { SMALL_AND_UP, LARGE_AND_UP, TINY_COL_MIN_HEIGHT } from '../lib/style';
+import { KeyK } from '../lib/types';
 
 interface TinyNavButtonProps {
   isLeft?: boolean;
@@ -32,8 +33,7 @@ const TinyNavButton = ({ isLeft, dispatch }: TinyNavButtonProps) => {
         e.preventDefault();
         dispatch({
           type: 'KEYPRESS',
-          key: isLeft ? '{prevEntry}' : '{nextEntry}',
-          shift: false,
+          key: { k: isLeft ? KeyK.PrevEntry : KeyK.NextEntry },
         });
       }}
     >

--- a/app/components/Preview.tsx
+++ b/app/components/Preview.tsx
@@ -20,12 +20,13 @@ import {
   PublishAction,
 } from '../reducers/reducer';
 import { SquareAndCols } from './Page';
-import { PuzzleInProgressT, Direction } from '../lib/types';
+import { PuzzleInProgressT, Direction, fromKeyboardEvent } from '../lib/types';
 import { useMatchMedia } from '../lib/hooks';
 import { SMALL_AND_UP_RULES } from '../lib/style';
 import { ClueMode } from './ClueMode';
 import { ContactLinks } from './ContactLinks';
 import { getCluedAcrossAndDown } from '../lib/viewableGrid';
+import { isSome } from 'fp-ts/lib/Option';
 
 const initializeState = (
   props: PuzzleInProgressT & AuthProps
@@ -64,16 +65,12 @@ export const Preview = (props: PuzzleInProgressT & AuthProps): JSX.Element => {
       if (tagName === 'textarea' || tagName === 'input') {
         return;
       }
-      if (e.metaKey || e.altKey || e.ctrlKey) {
-        return; // This way you can still do apple-R and such
+      const mkey = fromKeyboardEvent(e);
+      if (isSome(mkey)) {
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
+        dispatch(kpa);
+        e.preventDefault();
       }
-      const kpa: KeypressAction = {
-        type: 'KEYPRESS',
-        key: e.key,
-        shift: e.shiftKey,
-      };
-      dispatch(kpa);
-      e.preventDefault();
     },
     [dispatch]
   );

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -49,7 +49,14 @@ import { AuthContext, AuthPropsOptional } from './AuthContext';
 import { CrosshareAudioContext } from './CrosshareAudioContext';
 import { Overlay } from './Overlay';
 import { GridView } from './Grid';
-import { Direction, BLOCK, getClueText } from '../lib/types';
+import {
+  Direction,
+  BLOCK,
+  getClueText,
+  KeyK,
+  fromKeyboardEvent,
+  fromKeyString,
+} from '../lib/types';
 import {
   fromCells,
   addClues,
@@ -105,6 +112,7 @@ import {
 } from './PuzzleOverlay';
 import { I18nTags } from './I18nTags';
 import { t, Trans } from '@lingui/macro';
+import { isSome } from 'fp-ts/lib/Option';
 
 const ModeratingOverlay = dynamic(
   () => import('./ModerateOverlay').then((mod) => mod.ModeratingOverlay as any), // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -513,34 +521,19 @@ export const Puzzle = ({
 
   const physicalKeyboardHandler = useCallback(
     (e: KeyboardEvent) => {
-      // disable keyboard when paused / loading play
-      if (!(state.success && state.dismissedSuccess)) {
-        if (loadingPlayState || !state.currentTimeWindowStart) {
-          return;
-        }
-      }
       const tagName = (e.target as HTMLElement)?.tagName?.toLowerCase();
       if (tagName === 'textarea' || tagName === 'input') {
         return;
       }
-      if (e.metaKey || e.altKey || e.ctrlKey || e.key === 'CapsLock') {
-        return; // This way you can still do apple-R and such
+
+      const mkey = fromKeyboardEvent(e);
+      if (isSome(mkey)) {
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
+        dispatch(kpa);
+        e.preventDefault();
       }
-      const kpa: KeypressAction = {
-        type: 'KEYPRESS',
-        key: e.key,
-        shift: e.shiftKey,
-      };
-      dispatch(kpa);
-      e.preventDefault();
     },
-    [
-      dispatch,
-      loadingPlayState,
-      state.currentTimeWindowStart,
-      state.success,
-      state.dismissedSuccess,
-    ]
+    [dispatch]
   );
   useEventListener('keydown', physicalKeyboardHandler);
 
@@ -570,8 +563,11 @@ export const Puzzle = ({
 
   const keyboardHandler = useCallback(
     (key: string) => {
-      const kpa: KeypressAction = { type: 'KEYPRESS', key: key, shift: false };
-      dispatch(kpa);
+      const mkey = fromKeyString(key);
+      if (isSome(mkey)) {
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
+        dispatch(kpa);
+      }
     },
     [dispatch]
   );
@@ -919,8 +915,7 @@ export const Puzzle = ({
                   onClick={() => {
                     const kpa: KeypressAction = {
                       type: 'KEYPRESS',
-                      key: 'Escape',
-                      shift: false,
+                      key: { k: KeyK.Escape }
                     };
                     dispatch(kpa);
                   }}

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -521,6 +521,13 @@ export const Puzzle = ({
 
   const physicalKeyboardHandler = useCallback(
     (e: KeyboardEvent) => {
+      // Disable keyboard when paused / loading play
+      if (!(state.success && state.dismissedSuccess)) {
+        if (loadingPlayState || !state.currentTimeWindowStart) {
+          return;
+        }
+      }
+
       const tagName = (e.target as HTMLElement)?.tagName?.toLowerCase();
       if (tagName === 'textarea' || tagName === 'input') {
         return;
@@ -533,7 +540,13 @@ export const Puzzle = ({
         e.preventDefault();
       }
     },
-    [dispatch]
+    [
+      dispatch,
+      loadingPlayState,
+      state.currentTimeWindowStart,
+      state.success,
+      state.dismissedSuccess,
+    ]
   );
   useEventListener('keydown', physicalKeyboardHandler);
 

--- a/app/components/PuzzleStats.tsx
+++ b/app/components/PuzzleStats.tsx
@@ -12,7 +12,7 @@ import {
   KeypressAction,
 } from '../reducers/reducer';
 import { SquareAndCols } from './Page';
-import { Direction, PuzzleResult } from '../lib/types';
+import { Direction, fromKeyboardEvent, PuzzleResult } from '../lib/types';
 import { PuzzleStatsViewT } from '../lib/dbtypes';
 import {
   fromCells,
@@ -32,6 +32,7 @@ import { Emoji } from './Emoji';
 import { CSVLink } from 'react-csv';
 import { App, FieldValue } from '../lib/firebaseWrapper';
 import { useSnackbar } from './Snackbar';
+import { isSome } from 'fp-ts/lib/Option';
 
 export enum StatsMode {
   AverageTime,
@@ -222,16 +223,12 @@ export const PuzzleStats = (props: PuzzleStatsProps): JSX.Element => {
       if (tagName === 'textarea' || tagName === 'input') {
         return;
       }
-      if (e.metaKey || e.altKey || e.ctrlKey) {
-        return; // This way you can still do apple-R and such
+      const mkey = fromKeyboardEvent(e);
+      if (isSome(mkey)) {
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
+        dispatch(kpa);
+        e.preventDefault();
       }
-      const kpa: KeypressAction = {
-        type: 'KEYPRESS',
-        key: e.key,
-        shift: e.shiftKey,
-      };
-      dispatch(kpa);
-      e.preventDefault();
     },
     [dispatch]
   );

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -1,3 +1,4 @@
+import { isSome, none, Option, some } from 'fp-ts/lib/Option';
 import * as t from 'io-ts';
 import type { WordDBT } from './WordDB';
 
@@ -258,3 +259,84 @@ export const PuzzleInProgressStrictV = t.intersection([
   }),
 ]);
 export type PuzzleInProgressStrictT = t.TypeOf<typeof PuzzleInProgressStrictV>;
+
+export type Key
+  = { k: KeyK.AllowedCharacter, c: string }
+  | { k: Exclude<KeyK, KeyK.AllowedCharacter> };
+
+export enum KeyK {
+  ArrowRight,
+  ArrowLeft,
+  ArrowUp,
+  ArrowDown,
+  Space,
+  Tab,
+  ShiftTab,
+  Enter,
+  Backspace,
+  Delete,
+  Escape,
+  Tilde,
+  Dot,
+  Exclamation,
+  AllowedCharacter,
+  // Keys specific to on-screen keyboard
+  NumLayout,
+  AbcLayout,
+  Direction,
+  Next,
+  Prev,
+  NextEntry,
+  PrevEntry,
+  OskBackspace,
+  Rebus,
+  Block,
+}
+
+export const ALLOWABLE_GRID_CHARS = /^[A-Za-z0-9Ññ&]$/;
+
+export function fromKeyString(string: string): Option<Key> {
+  return fromKeyboardEvent({ key: string, shiftKey: false });
+}
+
+export function fromKeyboardEvent(event: { key: string, shiftKey: boolean }): Option<Key> {
+  const basicKey: Option<Exclude<KeyK, KeyK.AllowedCharacter>> = (() => {
+    switch (event.key) {
+    case 'ArrowLeft': return some(KeyK.ArrowLeft);
+    case 'ArrowRight': return some(KeyK.ArrowRight);
+    case 'ArrowUp': return some(KeyK.ArrowUp);
+    case 'ArrowDown': return some(KeyK.ArrowDown);
+    case ' ': return some(KeyK.Space);
+    case 'Tab': return !event.shiftKey
+      ? some(KeyK.Tab)
+      : some(KeyK.ShiftTab);
+    case 'Enter': return some(KeyK.Enter);
+    case 'Backspace': return some(KeyK.Backspace);
+    case 'Delete': return some(KeyK.Delete);
+    case 'Escape': return some(KeyK.Escape);
+    case '`': return some(KeyK.Tilde);
+    case '.': return some(KeyK.Dot);
+    case '!': return some(KeyK.Exclamation);
+    // Keys specific to on-screen keyboard
+    case '{num}': return some(KeyK.NumLayout);
+    case '{abc}': return some(KeyK.AbcLayout);
+    case '{dir}': return some(KeyK.Direction);
+    case '{next}': return some(KeyK.Next);
+    case '{prev}': return some(KeyK.Prev);
+    case '{nextEntry}': return some(KeyK.NextEntry);
+    case '{prevEntry}': return some(KeyK.PrevEntry);
+    case '{bksp}': return some(KeyK.OskBackspace);
+    case '{rebus}': return some(KeyK.Rebus);
+    case '{block}': return some(KeyK.Block);
+    default: return none;
+    }
+  })();
+
+  if (isSome(basicKey)) {
+    return some({ k: basicKey.value });
+  }
+  if (event.key.match(ALLOWABLE_GRID_CHARS)) {
+    return some({ k: KeyK.AllowedCharacter, c: event.key });
+  }
+  return none;
+}

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -276,7 +276,7 @@ export enum KeyK {
   Backspace,
   Delete,
   Escape,
-  Tilde,
+  Backtick,
   Dot,
   Exclamation,
   AllowedCharacter,
@@ -314,7 +314,7 @@ export function fromKeyboardEvent(event: { key: string, shiftKey: boolean }): Op
     case 'Backspace': return some(KeyK.Backspace);
     case 'Delete': return some(KeyK.Delete);
     case 'Escape': return some(KeyK.Escape);
-    case '`': return some(KeyK.Tilde);
+    case '`': return some(KeyK.Backtick);
     case '.': return some(KeyK.Dot);
     case '!': return some(KeyK.Exclamation);
     // Keys specific to on-screen keyboard

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -4,6 +4,9 @@ import {
   Direction,
   BLOCK,
   PuzzleInProgressT,
+  Key,
+  KeyK,
+  ALLOWABLE_GRID_CHARS,
 } from '../lib/types';
 import { DBPuzzleT, PlayWithoutUserT } from '../lib/dbtypes';
 import {
@@ -252,8 +255,7 @@ export interface PuzzleAction {
 
 export interface KeypressAction extends PuzzleAction {
   type: 'KEYPRESS';
-  key: string;
-  shift: boolean;
+  key: Key;
 }
 function isKeypressAction(action: PuzzleAction): action is KeypressAction {
   return action.type === 'KEYPRESS';
@@ -705,8 +707,6 @@ function closeRebus<T extends GridInterfaceState>(state: T): T {
   };
 }
 
-const ALLOWABLE_GRID_CHARS = /^[A-Za-z0-9Ññ&]$/;
-
 export function gridInterfaceReducer<T extends GridInterfaceState>(
   state: T,
   action: PuzzleAction
@@ -770,16 +770,15 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
   }
   if (isKeypressAction(action)) {
     const key = action.key;
-    const shift = action.shift;
     if (!key) {
       // This seems dumb to check for but at least once we've had key == undefined here
       // https://sentry.io/organizations/m-d/issues/1915351332/
       return state;
     }
-    if (key === '{num}' || key === '{abc}') {
+    if (key.k === KeyK.NumLayout || key.k === KeyK.AbcLayout) {
       return { ...state, showExtraKeyLayout: !state.showExtraKeyLayout };
     }
-    if (key === '`' && isBuilderState(state)) {
+    if (key.k === KeyK.Tilde && isBuilderState(state)) {
       const ci = cellIndex(state.grid, state.active);
       if (state.isEditable(ci)) {
         if (state.grid.highlighted.has(ci)) {
@@ -791,14 +790,14 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
       return { ...state };
     }
     if (state.isEnteringRebus) {
-      if (key.match(ALLOWABLE_GRID_CHARS)) {
-        return { ...state, rebusValue: state.rebusValue + key.toUpperCase() };
-      } else if (key === 'Backspace' || key === '{bksp}') {
+      if (key.k === KeyK.AllowedCharacter) {
+        return { ...state, rebusValue: state.rebusValue + key.c.toUpperCase() };
+      } else if (key.k === KeyK.Backspace || key.k === KeyK.OskBackspace) {
         return {
           ...state,
           rebusValue: state.rebusValue ? state.rebusValue.slice(0, -1) : '',
         };
-      } else if (key === 'Enter') {
+      } else if (key.k === KeyK.Enter) {
         return {
           ...closeRebus(state),
           wasEntryClick: false,
@@ -809,18 +808,18 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
             isPuzzleState(state) ? state.prefs : undefined
           ),
         };
-      } else if (key === 'Escape') {
+      } else if (key.k === KeyK.Escape) {
         return { ...state, isEnteringRebus: false, rebusValue: '' };
       }
       return closeRebus(state);
     }
-    if (key === '{rebus}' || key === 'Escape') {
+    if (key.k === KeyK.Rebus || key.k === KeyK.Escape) {
       const ci = cellIndex(state.grid, state.active);
       if (state.isEditable(ci)) {
         return { ...state, showExtraKeyLayout: false, isEnteringRebus: true };
       }
       return state;
-    } else if (key === ' ' || key === '{dir}') {
+    } else if (key.k === KeyK.Space || key.k === KeyK.Direction) {
       return {
         ...state,
         wasEntryClick: false,
@@ -829,35 +828,35 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: (state.active.dir + 1) % 2,
         },
       };
-    } else if (key === '{prev}') {
+    } else if (key.k === KeyK.Prev) {
       return {
         ...state,
         wasEntryClick: false,
         active: retreatPosition(state.grid, state.active),
       };
-    } else if (key === '{next}') {
+    } else if (key.k === KeyK.Next) {
       return {
         ...state,
         wasEntryClick: false,
         active: nextCell(state.grid, state.active),
       };
     } else if (
-      (key === 'Tab' && !shift) ||
-      key === '{nextEntry}' ||
-      key === 'Enter'
+      key.k === KeyK.Tab ||
+      key.k === KeyK.NextEntry ||
+      key.k === KeyK.Enter
     ) {
       return {
         ...state,
         wasEntryClick: false,
         active: moveToNextEntry(state.grid, state.active),
       };
-    } else if ((key === 'Tab' && shift) || key === '{prevEntry}') {
+    } else if (key.k === KeyK.ShiftTab || key.k === KeyK.PrevEntry) {
       return {
         ...state,
         wasEntryClick: false,
         active: moveToPrevEntry(state.grid, state.active),
       };
-    } else if (key === 'ArrowRight') {
+    } else if (key.k === KeyK.ArrowRight) {
       return {
         ...state,
         wasEntryClick: false,
@@ -869,7 +868,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Across,
         },
       };
-    } else if (key === 'ArrowLeft') {
+    } else if (key.k === KeyK.ArrowLeft) {
       return {
         ...state,
         wasEntryClick: false,
@@ -881,7 +880,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Across,
         },
       };
-    } else if (key === 'ArrowUp') {
+    } else if (key.k === KeyK.ArrowUp) {
       return {
         ...state,
         wasEntryClick: false,
@@ -893,7 +892,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Down,
         },
       };
-    } else if (key === 'ArrowDown') {
+    } else if (key.k === KeyK.ArrowDown) {
       return {
         ...state,
         wasEntryClick: false,
@@ -906,7 +905,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         },
       };
     } else if (
-      (key === '.' || key === '{block}') &&
+      (key.k === KeyK.Dot || key.k === KeyK.Block) &&
       state.grid.allowBlockEditing
     ) {
       const ci = cellIndex(state.grid, state.active);
@@ -920,8 +919,8 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         };
       }
       return state;
-    } else if (key.match(ALLOWABLE_GRID_CHARS)) {
-      const char = key.toUpperCase();
+    } else if (key.k === KeyK.AllowedCharacter) {
+      const char = key.c.toUpperCase();
       state = enterText(state, char);
       return {
         ...state,
@@ -933,7 +932,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           isPuzzleState(state) ? state.prefs : undefined
         ),
       };
-    } else if (key === 'Backspace' || key === '{bksp}') {
+    } else if (key.k === KeyK.Backspace || key.k === KeyK.OskBackspace) {
       const ci = cellIndex(state.grid, state.active);
       if (state.isEditable(ci)) {
         const symmetry = isBuilderState(state) ? state.symmetry : Symmetry.None;
@@ -949,7 +948,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         wasEntryClick: false,
         active: retreatPosition(state.grid, state.active),
       };
-    } else if (key === 'Delete') {
+    } else if (key.k === KeyK.Delete) {
       const ci = cellIndex(state.grid, state.active);
       if (state.isEditable(ci)) {
         const symmetry = isBuilderState(state) ? state.symmetry : Symmetry.None;

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -778,7 +778,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
     if (key.k === KeyK.NumLayout || key.k === KeyK.AbcLayout) {
       return { ...state, showExtraKeyLayout: !state.showExtraKeyLayout };
     }
-    if (key.k === KeyK.Tilde && isBuilderState(state)) {
+    if (key.k === KeyK.Backtick && isBuilderState(state)) {
       const ci = cellIndex(state.grid, state.active);
       if (state.isEditable(ci)) {
         if (state.grid.highlighted.has(ci)) {


### PR DESCRIPTION
- Adds type & enum for keypresses
- No longer eats up unrecognized inputs

I skipped figuring out those builder hotkeys for now :P  
Also, should there be more allowed characters? Maybe `/^[\pL\pN]$/`?

Fixes #353 