### PR TITLE
Mention private-ness when publishing

### DIFF
--- a/app/components/PublishOverlay.tsx
+++ b/app/components/PublishOverlay.tsx
@@ -8,6 +8,7 @@ import { Emoji } from './Emoji';
 import { getDocRef } from '../lib/firebaseWrapper';
 import { DBPuzzleT } from '../lib/dbtypes';
 import { slugify, STORAGE_KEY } from '../lib/utils';
+import lightFormat from 'date-fns/lightFormat';
 import { ButtonAsLink, Button } from './Buttons';
 import { serverTimestamp, setDoc } from 'firebase/firestore';
 
@@ -93,6 +94,18 @@ export function PublishOverlay(props: {
         <p>
           Thanks for constructing a puzzle! <Emoji symbol="😎" />
         </p>
+        {(!(props.toPublish.pv === undefined || props.toPublish.pv === false) && (props.toPublish.pvu === undefined)) ? (
+          <p>
+            This puzzle will be posted as private.
+          </p>
+          ) : null
+        }
+        {(props.toPublish.pvu && (props.toPublish.pvu.toMillis() > Date.now()))? (
+          <p>
+            This puzzle will be posted as private until {lightFormat(props.toPublish.pvu.toDate(), "M/d/y' at 'h:mma")}.
+          </p>
+          ) : null
+        }
         <p css={{ color: 'var(--error)' }}>
           All puzzles are reviewed and subject to removal at any time for any
           reason (e.g. if the content is deemed offensive or if it is found to


### PR DESCRIPTION
When I'm publishing a puzzle early to get feedback or schedule a puzzle's release, I always stop to triple-check that I'm not publishing it publicly. This is to provide some reassurance to the creator about the puzzle's status.

<details>
<summary>Example screenshots</summary>

## Private
<img width="336" alt="image" src="https://user-images.githubusercontent.com/7526790/223859301-c2e8f7d8-7d85-4a64-afb4-05f2890202d1.png">


## Private Until
<img width="329" alt="image" src="https://user-images.githubusercontent.com/7526790/223858966-4c43c664-f6c5-415a-9265-bbd74cd27e74.png">


## Neither private nor private until
<img width="333" alt="image" src="https://user-images.githubusercontent.com/7526790/223860030-85060547-c9c3-40c3-9bc6-48cf0fbbae00.png">
</details>