### PR TITLE
Use display name on pause/resume modal on puzzle page

### DIFF
--- a/app/components/PuzzleOverlay.tsx
+++ b/app/components/PuzzleOverlay.tsx
@@ -97,7 +97,7 @@ export const PuzzleOverlay = (props: SuccessOverlayProps | BeginPauseProps) => {
   let loginButton: ReactNode = t`Login (via Google) to save your puzzle progress/stats`;
   if (!authContext.loading) {
     if (authContext.user?.email) {
-      loginButton = t`Logged in as ${authContext.user.email}`;
+      loginButton = t`Logged in as ${authContext.user.displayName || authContext.user.email}`;
     } else if (authContext.user) {
       loginButton = (
         <>

--- a/app/pages/account.tsx
+++ b/app/pages/account.tsx
@@ -159,6 +159,8 @@ export const AccountPage = ({ user, constructorPage, prefs }: AuthProps) => {
             ''
           )}
           is displayed next to any comments you make or puzzles you create.
+          
+          If set, it will also be used in the pause/resume modal on each puzzle&apos;s page instead of your email address.
         </p>
         <DisplayNameForm />
         <h3>Notification Settings</h3>

--- a/app/pages/account.tsx
+++ b/app/pages/account.tsx
@@ -159,8 +159,6 @@ export const AccountPage = ({ user, constructorPage, prefs }: AuthProps) => {
             ''
           )}
           is displayed next to any comments you make or puzzles you create.
-          
-          If set, it will also be used in the pause/resume modal on each puzzle&apos;s page instead of your email address.
         </p>
         <DisplayNameForm />
         <h3>Notification Settings</h3>


### PR DESCRIPTION
This will allow one to be logged in, load a puzzle, and not leak their own email address to an observer.

It's also consistent with the comment and puzzle user displays.

<details>
<summary>Images</summary>

## Using display name
<img width="727" alt="image" src="https://user-images.githubusercontent.com/7526790/223888680-527a591b-d6aa-4585-bfbe-b4f021231136.png">

## When display name is null
Behavior is the same as today, showing a user's email.

## Account page

<img width="719" alt="image" src="https://user-images.githubusercontent.com/7526790/223888748-4914aa57-b3fe-4158-b733-c6a400d27dea.png">

</details>


Resolves #376.