### PR TITLE
Teach usePagination to load previous data

### DIFF
--- a/app/firestore.indexes.json
+++ b/app/firestore.indexes.json
@@ -10,6 +10,20 @@
         },
         {
           "fieldPath": "p",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "c",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "a",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "p",
           "order": "DESCENDING"
         }
       ]

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -38,6 +38,8 @@ export const DashboardPage = ({ user, constructorPage }: AuthProps) => {
     docs: authoredPuzzles,
     loadMore: loadMoreAuthored,
     hasMore: hasMoreAuthored,
+    hasPrevious: hasPreviousAuthored,
+    loadPrevious: loadPreviousAuthored
   } = usePaginatedQuery(authoredQuery, DBPuzzleV, 8, authoredMapper);
 
   return (
@@ -87,12 +89,21 @@ export const DashboardPage = ({ user, constructorPage }: AuthProps) => {
             {loadingAuthored ? (
               <p>Loading...</p>
             ) : (
-              hasMoreAuthored && (
-                <ButtonAsLink
-                  onClick={loadMoreAuthored}
-                  text="Older puzzles &rarr;"
-                />
-              )
+              <>
+                {hasPreviousAuthored && (
+                  <ButtonAsLink
+                    onClick={loadPreviousAuthored}
+                    text="&larr; Newer puzzles"
+                  />
+                )}
+                {hasPreviousAuthored && hasMoreAuthored && <>&nbsp;|&nbsp;</>}
+                {hasMoreAuthored && (
+                  <ButtonAsLink
+                    onClick={loadMoreAuthored}
+                    text="Older puzzles &rarr;"
+                  />
+                )}
+              </>
             )}
           </div>
         ) : (


### PR DESCRIPTION
## Summary

- Teach usePaginatedQuery to load previous data
- Use this on the constructor dashboard to enable someone to load "Newer puzzles"

Note: this did require the creation of a composite index. When I loaded the page that involved the composite index, firebase provided me with a URL that loaded a dialog within firebase that was offering to create the index on my behalf. I'm not yet sure if there's a programmatic way to do this in advance of deploying this code.

Specifically, we'll need to add this index to collection `c`, which loads data in a reverse of the manner that the Constructor Dashboard currently loads data:
- `a: ASC, p: ASC, __name__: ASC`

This enables us to use the first result of the paginated query as the argument to `endBefore` in conjunction with `limitToLast`.

## Future work
We may need to create a similar composite index for the UnfinishedPuzzleList (which also uses `usePaginatedQuery`) when/if we add the "Newer puzzle" pagination to that part of the app.


## Screenshots
<details>
<summary>screenshots</summary>

## When both pagination options are showing:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/7526790/223937664-52b5e186-9c64-491e-9acd-85d056cf9dc4.png">

</details>


Resolves #396
Resolves #384