### PR TITLE
Teach unfinished solves about newer puzzles

### DIFF
--- a/app/components/UnfinishedPuzzleList.tsx
+++ b/app/components/UnfinishedPuzzleList.tsx
@@ -40,6 +40,8 @@ export function UnfinishedPuzzleList({ user }: { user: User | undefined }) {
     docs: unfinishedPuzzles,
     loadMore: loadMoreUnfinished,
     hasMore: hasMoreUnfinished,
+    hasPrevious: hasPreviousUnfinished,
+    loadPrevious: loadPreviousUnfinished,
   } = usePaginatedQuery(unfinishedQuery, LegacyPlayV, 4, playMapper);
 
   if (unfinishedPuzzles.length) {
@@ -63,12 +65,21 @@ export function UnfinishedPuzzleList({ user }: { user: User | undefined }) {
             <Trans>Loading...</Trans>
           </p>
         ) : (
-          hasMoreUnfinished && (
+          <>
+          {hasPreviousUnfinished && (
+            <ButtonAsLink
+              onClick={loadPreviousUnfinished}
+              text={'← ' + t`Newer unfinished solves`}
+            />
+            )}
+          {hasPreviousUnfinished && hasMoreUnfinished && <>&nbsp;|&nbsp;</>}
+          {hasMoreUnfinished && (
             <ButtonAsLink
               onClick={loadMoreUnfinished}
               text={t`Older unfinished solves` + ' →'}
             />
-          )
+          )}
+          </>
         )}
       </>
     );


### PR DESCRIPTION
- Enable a logged-in user to page through older (and then newer) puzzles in the unfinished puzzles section of the home page.

This is follow up from #405.

<details>
<summary>screenshots</summary>
## When there are both newer and older puzzles
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/7526790/224353812-084a8e0c-f7ef-4fe0-8a9e-350eaf4efd71.png">

</details>